### PR TITLE
don't add spa

### DIFF
--- a/.ci/linux/package.sh
+++ b/.ci/linux/package.sh
@@ -104,7 +104,6 @@ xvfb-run -a ./sharun-aio l -p -v -e -s -k \
 	$LIBDIR/qt6/plugins/xcbglintegrations/* \
 	$LIBDIR/qt6/plugins/wayland-*/* \
 	$LIBDIR/pulseaudio/* \
-	$LIBDIR/spa-0.2/*/* \
 	$LIBDIR/alsa-lib/*
 
 rm -f ./sharun-aio


### PR DESCRIPTION
this is needed only for pipewire. 

And I made sure, somehow these builds do not make use of pipewire at all, no idea what the trick is since Escary's build do end up using pipewire as I checked it with strace. 