### PR TITLE
include `ARCH` in zsync info

### DIFF
--- a/.ci/linux/package.sh
+++ b/.ci/linux/package.sh
@@ -61,7 +61,7 @@ cp ../dist/org.eden_emu.eden.svg .
 
 ln -sf ./org.eden_emu.eden.svg ./.DirIcon
 
-UPINFO='gh-releases-zsync|eden-emulator|Releases|latest|*.AppImage.zsync'
+UPINFO="gh-releases-zsync|eden-emulator|Releases|latest|*-$ARCH.AppImage.zsync"
 
 if [ "$DEVEL" = 'true' ]; then
 	sed -i 's|Name=Eden|Name=Eden Nightly|' ./org.eden_emu.eden.desktop


### PR DESCRIPTION
needed to differentiate between the newer artifacts, else everything updates to the steamdeck version. 