### PR TITLE
windows: fixup forcing clang

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,7 +93,7 @@ jobs:
           arch: ${{ matrix.os.arch }}
 
       - name: Force Clang 20
-        if: matrix.compiler == 'clang'
+        if: matrix.compiler.program == 'clang'
         shell: bash
         run: |
           echo "C:/Program Files/LLVM/bin" >> $GITHUB_PATH


### PR DESCRIPTION
I dont think it's necessary since builds are using clang, but here's the fix anyway