### PR TITLE
add privileges to build dwarfs image profile

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -73,7 +73,9 @@ jobs:
     name: "AppImage ${{ matrix.os.arch }} ${{ matrix.compiler.program }} ${{ matrix.compiler.target }}"
     needs: [set-matrix]
     runs-on: ${{ matrix.os.runs-on }}
-    container: ghcr.io/pkgforge-dev/archlinux:latest
+    container:
+      image: ghcr.io/pkgforge-dev/archlinux:latest
+      options: --privileged --device /dev/fuse
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Turns out `OPTIMIZE_LAUNCH=1` wasn't doing anything because the temp appimage that gets in the CI cannot use FUSE to mount, so it was falling back to extract and run which does not create the dwarfs profile 💀

