### PR TITLE
add `libxss` and `libxcursor`

### DIFF
--- a/.ci/deps/arch.sh
+++ b/.ci/deps/arch.sh
@@ -27,6 +27,8 @@ pacman -Syu --noconfirm --overwrite "*" \
 	libva \
 	libvdpau \
 	libvpx \
+	libxcursor \
+	libxss \
 	lld \
 	llvm \
     lxqt-qtplugin \


### PR DESCRIPTION
These libs get dlopened by Qt at runtime, we already always include them, however they are totally missing from the CI runner.

<img width="603" height="147" alt="image" src="https://github.com/user-attachments/assets/a23a3dde-9cff-4c03-bd86-f5d1457acc52" />

<img width="597" height="151" alt="image" src="https://github.com/user-attachments/assets/5ee74eaf-8d16-4b4c-85ec-d6474aa4711f" />
